### PR TITLE
Solución superposición logotipo de marca sobre descripción de producto

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -12117,8 +12117,12 @@ body#checkout section.checkout-step .step-title .step-number {
 }
 
 .product-manufacturer .brand_centercolumn {
-    position: absolute;
+    position: static;
     right: 1rem;
+}
+
+.product-manufacturer {
+    text-align: right;
 }
 
 .product-manufacturer .brand_centercolumn img {


### PR DESCRIPTION
Soluciona el bug #3 en el cual la imagen de marca superponía a la descripción de producto, ahora se sitúa encima del texto en la parte derecha


